### PR TITLE
Add "Best of JavaScript" weekly rankings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Awesome JavaScript Newsletter](https://js.libhunt.com/newsletter). A collection of awesome browser-side JavaScript libraries, resources and shiny things.
 - [TypeScript Weekly](https://www.typescript-weekly.com/). The best TypeScript links every week, right in your box.
 - [JSter](http://jster.net/blog). No nonsense list of curated JavaScript links to your mailbox once every two weeks. [Subscribe](https://us7.list-manage.com/subscribe?u=ed40c0084a0c5ba31b3365d65&id=ec6f32bf5e).
+- [Best of JavaScript](https://weekly.bestofjs.org/) Weekly rankings about the most popular open-source projects related to Node.js and the web platform.
 
 #### React
 


### PR DESCRIPTION
Hello Dmitry @zudochkin 
Thank you for maintaining this project.

I'd like to suggest adding https://weekly.bestofjs.org, the weekly newsletter related to [Best of JavaScript](https://bestofjs.org/) site.

> A curated list of the most popular open-source projects related to the web platform and Node.js.

Every week, the subscribers get an email about the 10 most popular projects of the week, from the projects tracked by _Best of JavaScript_.

The newsletter was launched one year ago, the [issue number 62](https://weekly.bestofjs.org/issues/62) has just been published.

Thank you!