### PR TITLE
Remove Volt Framework from Ruby section

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,6 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Ruby Weekly](https://rubyweekly.com/). A free, once–weekly e-mail round-up of Ruby news and articles.
 - [Ruby Articles](https://thoughtbot.com/blog/tags/ruby). Ruby posts by [Thoughtbot](https://thoughtbot.com)
 - [Rails Weekly](https://rails-weekly.ongoodbits.com/). Weekly inside scoop of interesting commits, pull requests and more from Rails, delivered to your inbox every Friday.
-- [Volt Framework](http://voltframework.com/). Volt is a framework for building data rich web applications shockingly fast.
 - [Awesome Ruby Newsletter](https://ruby.libhunt.com/newsletter). A collection of awesome Ruby gems, tools, frameworks and software.
 
 ### PHP


### PR DESCRIPTION
Volt Framework is not a newsletter. Besides, voltframework.com leads to a 404 and last commit is 6 years old (https://github.com/voltrb/volt).