### PR TITLE
Remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 
 ### Data Visualization
 
-- [Data Visualization & D3.js Weekly Newsletter](https://www.dashingd3js.com/data-visualization-and-d3-newsletter). Get D3.js and Data Visualization news, articles, jobs and more delivered to your inbox every Tuesday.
 - [Best in Visual Storytelling](https://us16.list-manage.com/subscribe?u=5c12dabe1e59a9fbde1174b8c&id=e27a48af53). Monday roundup of the best in data journalism from the past week. Paid version also includes data visualization job postings.
 - [Generative Collective](https://generative.substack.com/). News, tutorials, articles and inspirations covering the generative / functional arts every Saturday morning.
 


### PR DESCRIPTION
Hey! I noticed a broken link, I think dashingd3js stopped publishing its newsletters.
![image](https://user-images.githubusercontent.com/54525904/151033907-b8da4971-da95-4249-a3cc-5d30e9d62623.png)
