### PR TITLE
Next.js News has been inactive since April 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [This Week In React](https://this-week-in-react.org/). Weekly coverage of interesting pull requests, discussions, and RFCs around React Core and React DOM. Coming out every Friday.
 - [Tiny React](https://tinyreact.email). Top 3 React articles of the week in your inbox.
 - [React Explained](https://www.getrevue.co/profile/react-explained). A weekly newsletter for people learning React.
-- [Next.js News](https://nextjsnews.com). Next.js focused newsletter sent every month. Contains reviews of upcoming features, best articles, tools, and plugins.
 
 #### EmberJS
 


### PR DESCRIPTION
I've been reviewing a few sections and stumbled upon a few inactive newsletters.

Please note that I publish a few newsletters in these sections. I'm only trying to clean up.