### PR TITLE
Adding unzip.dev 

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [TechMeme](https://www.techmeme.com/). Techmeme is a aggregated, filtered, archiveable summary in near real-time of what is new and generating conversation in technology.
 - [Unzip.dev](https://unzip.dev/). Developer trends newsletter, unpacking one trend at a time.
 
+
 ## Leadership
 
 - [Software Lead Weekly](https://softwareleadweekly.com/). Insightful articles about company culture, leadership and building software in general.

--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Four Short Links](https://www.oreilly.com/radar/topics/four-short-links/). 4 short links about (mostly research oriented) technology every weekday.
 - [The Morning Paper](https://blog.acolyer.org/). An interesting/influential/important paper from the world of CS every weekday morning, as selected by Adrian Colyer.
 - [TechMeme](https://www.techmeme.com/). Techmeme is a aggregated, filtered, archiveable summary in near real-time of what is new and generating conversation in technology.
+- [Unzip.dev](https://unzip.dev/). Developer trends newsletter, unpacking one trend at a time.
 
 ## Leadership
 


### PR DESCRIPTION
[Unzip.dev](https://unzip.dev) is a developer trends newsletter, where I unpack one trend every few weeks, like trends.vc.
You can see the latest posts here: [unzip.dev/archive](https://unzip.dev/archive/)