### PR TITLE
added iOS Dev Tools under swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [iOS Goodies](https://ios-goodies.com). Weekly iOS newsletter. [Archive](https://ios-goodies.com/archive).
 - [Indie iOS Focus Weekly](https://indieiosfocus.com). Best iOS development, marketing, Swift, design, and Xcode links.
 - [Swift Developments](https://andybargh.com/swiftdevelopments/). Weekly curated newsletter containing a hand picked selection of the latest links, videos, tools and tutorials for people interested in designing and developing their own iOS, macOS, watchOS and tvOS apps using Swift.
-- [iOS Dev Tools Newsletter](https://iosdev.tools/). The best tools for iOS developers, updated on a weekly basis.
+- [iOS Dev Tools Newsletter](https://iosdev.tools/). The best tools for iOS developers, updated weekly.
 
 ### Go
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [iOS Goodies](https://ios-goodies.com). Weekly iOS newsletter. [Archive](https://ios-goodies.com/archive).
 - [Indie iOS Focus Weekly](https://indieiosfocus.com). Best iOS development, marketing, Swift, design, and Xcode links.
 - [Swift Developments](https://andybargh.com/swiftdevelopments/). Weekly curated newsletter containing a hand picked selection of the latest links, videos, tools and tutorials for people interested in designing and developing their own iOS, macOS, watchOS and tvOS apps using Swift.
+- [iOS Dev Tools Newsletter](https://iosdev.tools/). The best tools for iOS developers, updated on a weekly basis.
 
 ### Go
 


### PR DESCRIPTION
iOS Dev Tools is a free weekly newsletter containing a selection of tools specifically for iOS developers. Next to that users can use the website [iosdev.tools](https://iosdev.tools) to search for tools and read interviews with indie developers.