### PR TITLE
Remove inactive newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,9 +322,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 
 ## Open Source
 
-- [TinyOpenSource](https://tinyopensource.email). Top 5 updates from the Open-Source world, straight to your inbox. Short and Sweet.
 - [BSD Weekly](https://bsdweekly.com/). A free, once–weekly e-mail round-up of BSD news and articles.
-- [MacMost](https://macmost.com/macmost-weekly-newsletter). Latest MacMost tutorials, tips and news right in your inbox every week.
 - [NixOS Weekly](https://weekly.nixos.org). Latest News for [NixOS](https://nixos.org)
 - [Console Weekly](https://console.substack.com/). Discover cool open-source projects and an interview with one of the developers every week.
 - [FOSS Weekly](https://fossweekly.beehiiv.com/). The easiest way to keep up with Open Source Software.


### PR DESCRIPTION
Removed an inactive newsletter and a mac related newsletter from the open source section. (they must have added the mac one thinking OS means opeating system?)