### PR TITLE
Add Short Ruby Newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Rails Weekly](https://rails-weekly.ongoodbits.com/). Weekly inside scoop of interesting commits, pull requests and more from Rails, delivered to your inbox every Friday.
 - [Awesome Ruby Newsletter](https://ruby.libhunt.com/newsletter). A collection of awesome Ruby gems, tools, frameworks and software.
 - [Women on Rails Newsletter](https://womenonrailsinternational.substack.com/). A bi-monthly newsletter about Ruby on Rails and the web. Available in English, French, Spanish and Italian.
+- [Short Ruby Newsletter](https://newsletter.shortruby.com). A visual weekly newsletter about everything happening in Ruby world
+
 ### PHP
 
 - [PHP Weekly](http://www.phpweekly.com/). A free once-a-week newsletter, featuring some great articles, news and blog posts.


### PR DESCRIPTION
Short Ruby Newsletter is a visual newsletter about what is happening in Ruby's world

It is focused on Ruby code samples and includes any interesting conversation about Ruby and the Ruby ecosystem.