### PR TITLE
Adds IndieWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Indie iOS Focus Weekly](https://indieiosfocus.com). Best iOS development, marketing, Swift, design, and Xcode links.
 - [Swift Developments](https://andybargh.com/swiftdevelopments/). Weekly curated newsletter containing a hand picked selection of the latest links, videos, tools and tutorials for people interested in designing and developing their own iOS, macOS, watchOS and tvOS apps using Swift.
 - [iOS Dev Tools Newsletter](https://iosdev.tools/). The best tools for iOS developers, updated weekly.
+- [Indie Watch](https://indie.watch/). Weekly interviews with successful iOS & macOS developers about strategies and tips you can use to create profitable indie apps. 
 
 ### Go
 


### PR DESCRIPTION
Adds the Indie Watch newsletter - https://indie.watch/ - a weekly newsletter that features successful apps from independent iOS and macOS developers.

In each issue, we talk to a new developer and we hear their story, discuss how they came up with their app idea, marketed it, plans for the future, and mistakes they made along the way.