### PR TITLE
Update Go newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,8 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 
 ### Go
 
-- [Go Newsletter](https://golangweekly.com/). A weekly newsletter about the Go programming language. [Archive](https://golangweekly.com/issues).
-- [Awesome Go Newsletter](https://go.libhunt.com/newsletter). A weekly overview of the most popular Go news, articles and libraries.
-- [Go Gazette](http://www.go-gazette.com/). Weekly curated blogs and tools for Golang seniors.
-- [GoNotícias](https://gonoticias.substack.com/). A weekly newsletter about the Go programming language in Portuguese.
-- [Gopherit!](https://gopherit.substack.com). Advanced and beginner tips, videos, and articles about Golang, bi-Weekly newsletter.
+- [Golang Weekly](https://golangweekly.com/). A weekly newsletter about the Go programming language. [Archive](https://golangweekly.com/issues).
+- [Awesome Go Weekly](https://go.libhunt.com/newsletter). A weekly overview of the most popular Go news, articles and libraries.
 
 ### R
 


### PR DESCRIPTION
Some updates to the Go newsletters:

* Go Newsletter is called Golang Weekly.
* Awesome Go Newsletter is called Awesome Go Weekly.
* Go Gazzette redirects to Golang Weekly and has been removed from the list.
* GoNotícias has not been updated since 2021 and has been removed from the list.
* Gopherit! has only 2 publications and last one was in 2023. It has been removed from the list.