### PR TITLE
Update React section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,10 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 
 #### React
 
-- [This Week In React](https://thisweekinreact.com). Weekly newsletter for experienced React and React-Native developers.
-- [React Newsletter](https://reactnewsletter.com/). The free, weekly newsletter of the best React.js news and articles.
-- [React Native Newsletter](https://reactnativenewsletter.com/). Free occasional summary of React Native news, articles, issues & pull requests, libraries and apps.
-- [React Native Now](https://reactnativenow.com/). Hand picking the best React Native news, tutorials, libraries, articles, and videos.
-- [React Digest](https://reactdigest.net/). A weekly newsletter for React developers with top 5 links. [Archive](https://reactdigest.net/digests).
+- [React Digest](https://reactdigest.net/). A carefully curated weekly newsletter for React developers.
 - [React Status](https://react.statuscode.com/). A weekly roundup of the latest React and React Native links and tutorials.
 - [Awesome React Newsletter](https://react.libhunt.com/newsletter). A weekly overview of the most popular React news, articles and libraries.
+- [This Week In React](https://thisweekinreact.com). Weekly newsletter for experienced React and React-Native developers.
 - [Nextjs Weekly](https://nextjsweekly.com/). A newsletter of the best Next.js articles, tools and projects.
 
 #### EmberJS


### PR DESCRIPTION
Hopefully, this is not too controversial.

I've noticed that in https://github.com/zudochkin/awesome-newsletters/pull/203 @slorber moved and added a bunch of newsletters and reshuffled the order of the section. React Digest (I'm the author) has been publishing steadily every week [since 2015](https://newsletter.reactdigest.net/p/227). Peter Cooper's React Status has been around [since 2016](https://react.statuscode.com/issues/1) publishing high quality content. Both of them have been [on the list](https://github.com/zudochkin/awesome-newsletters/blob/master/CONTRIBUTING.md) for at least the last 5 years.

Personally, I'm not the biggest fan of Awesome React Newsletter as it seems to be automated but it's been around for a while too and should keep its spot.

Also, I've removed a few inactive or broken newsletters in the section. Let me know if you'd prefer to split it into separate PRs:

* The React Native Newsletter hasn't published [a new issue in 4 months](https://reactnativenewsletter.com/past-issues).
* React Newsletter hasn't published [a new issue in 9 months](https://reactnewsletter.com/issues).
* React Native Newsletter doesn't have [a subscribe form and there isn't an archive](https://www.atomlab.dev/react-native-newsletter).

The order matters as people discover newsletters that way. If there are inactive ones they tend to give up after going through a few.

Thank you!